### PR TITLE
Allow syntax highlighting for new line {

### DIFF
--- a/grammars/protocol buffer.cson
+++ b/grammars/protocol buffer.cson
@@ -17,7 +17,7 @@
     'name': 'meta.import.declaration.protobuf'
   }
   {
-    'begin': '\\b(message)\\s+([A-Za-z0-9_]+)\\s*\\{'
+    'begin': '\\b(message)\\s+([A-Za-z0-9_]+)'
     'captures':
       '1':
         'name': 'storage.type.message.protobuf'
@@ -39,7 +39,7 @@
   }
 
   {
-    'begin': '\\b(enum)\\s+([A-Za-z0-9_]+)\\s*\\{'
+    'begin': '\\b(enum)\\s+([A-Za-z0-9_]+)'
     'beginCaptures':
       '1':
         'name': 'storage.type.enum.protobuf'
@@ -69,7 +69,7 @@
     ]
   }
   {
-    'begin': '\\b(service)\\s+([A-Za-z0-9_]+)\\s*\\{'
+    'begin': '\\b(service)\\s+([A-Za-z0-9_]+)'
     'beginCaptures':
       '1':
         'name': 'storage.type.enum.protobuf'
@@ -91,7 +91,7 @@
           '5':
             'name': 'keyword.other.stream.protobuf'
           '6':
-            'name': 'variable.parameter.response-type.protobuf'  
+            'name': 'variable.parameter.response-type.protobuf'
         'match': '\\b(rpc)\\s+([A-Za-z0-9_]+)\\s+\\(([A-Za-z0-9_]+)\\)\\s*(returns)\\s*\\((stream\\s+)?([A-Za-z0-9_]+)\\)\\s*;'
         'name': 'meta.individual-rpc-call.protobuf'
       }
@@ -208,7 +208,7 @@
     'end': '\\n'
     'name': 'comment.line.double-slash.protobuf'
   'extend_block':
-    'begin': '\\b(extend)\\s+([A-Za-z0-9_]+)\\s*\\{'
+    'begin': '\\b(extend)\\s+([A-Za-z0-9_]+)'
     'captures':
       '1':
         'name': 'storage.type.extend.protobuf'


### PR DESCRIPTION
Atom when matching only considers a single line it seems. So as best I tried I couldn't include the `{`
So I've removed it to make sure it works over multi-lines where the `{` is newlined.

This resolves #4.