### PR TITLE
fix 'meta.individual-rpc-call.protobuf' pattern

### DIFF
--- a/grammars/protocol buffer.cson
+++ b/grammars/protocol buffer.cson
@@ -85,14 +85,16 @@
           '2':
             'name': 'entity.name.function.service-rpc.protobuf'
           '3':
-            'name': 'variable.parameter.request-type.protobuf'
-          '4':
-            'name': 'keyword.operator.returns.protobuf'
-          '5':
             'name': 'keyword.other.stream.protobuf'
+          '4':
+            'name': 'variable.parameter.request-type.protobuf'
+          '5':
+            'name': 'keyword.operator.returns.protobuf'
           '6':
+            'name': 'keyword.other.stream.protobuf'
+          '7':
             'name': 'variable.parameter.response-type.protobuf'
-        'match': '\\b(rpc)\\s+([A-Za-z0-9_]+)\\s+\\(([A-Za-z0-9_]+)\\)\\s*(returns)\\s*\\((stream\\s+)?([A-Za-z0-9_]+)\\)\\s*;'
+        'match': '\\b(rpc)\\s+([A-Za-z0-9_]+)\\s+\\((stream\\s+)?([A-Za-z0-9_\x2e]+)\\)\\s*(returns)\\s*\\((stream\\s+)?([A-Za-z0-9_\x2e]+)\\)\\s*;'
         'name': 'meta.individual-rpc-call.protobuf'
       }
       {


### PR DESCRIPTION
- ‘stream’ can appear before request-type
- Full stop character can be in name of request/response type
(e.g. ‘google.protobuf.Empty’)